### PR TITLE
convert hooks into soft hooks

### DIFF
--- a/test/hook.js
+++ b/test/hook.js
@@ -17,28 +17,7 @@ test("Hooks are added to a hooks object on a node", function (assert) {
         "value": "not a hook"
     }, [], null, null)
 
-    assert.equal(node.hooks.id, propValue)
-    assert.equal(node.descendantHooks, false)
-    assert.end()
-})
-
-test("Node child hooks are identified", function (assert) {
-    function Prop() {}
-    Prop.prototype.hook = function () {}
-    var propValue = new Prop()
-
-    var node = new Node("div", {
-        "id": propValue,
-        "value": "not a hook"
-    }, [], undefined, undefined)
-
-    var parentNode = new Node("div", {
-        "id": "not a hook"
-    }, [node], undefined, undefined)
-
-    assert.equal(node.hooks.id, propValue)
-    assert.equal(parentNode.hooks, undefined)
-    assert.ok(parentNode.descendantHooks)
+    assert.equal(node.properties.id, propValue)
     assert.end()
 })
 
@@ -168,7 +147,7 @@ test("two hooks of same interface", function (assert) {
     assert.end()
 })
 
-test("all hooks are called", function (assert) {
+test("hooks are not called on trivial diff", function (assert) {
     var counters = {
         a: 0,
         b: 0,
@@ -185,18 +164,18 @@ test("all hooks are called", function (assert) {
     ])
 
     var rootNode = create(vnode)
-    assert.equal(counters.a, 1)
-    assert.equal(counters.b, 1)
-    assert.equal(counters.c, 1)
+    assert.equal(counters.a, 1, "counters.a")
+    assert.equal(counters.b, 1, "counters.b")
+    assert.equal(counters.c, 1, "counters.c")
 
     var patches = diff(vnode, vnode)
-    assert.equal(patchCount(patches), 3)
+    assert.equal(patchCount(patches), 0, "patches")
 
     var newRoot = patch(rootNode, patches)
     assert.equal(newRoot, rootNode)
-    assert.equal(counters.a, 2)
-    assert.equal(counters.b, 2)
-    assert.equal(counters.c, 2)
+    assert.equal(counters.a, 1, "counters.a patch")
+    assert.equal(counters.b, 1, "counters.b patch")
+    assert.equal(counters.c, 1, "counters.c patch")
     assert.end()
 })
 

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -41,6 +41,8 @@ function removeProperty(node, props, previous, propName) {
             } else {
                 node[propName] = null
             }
+        } else if (previousValue && previousValue.unhook) {
+            previousValue.unhook(node, propName, previousValue)
         }
     }
 }

--- a/virtual-hyperscript/test/ev-hook.js
+++ b/virtual-hyperscript/test/ev-hook.js
@@ -6,7 +6,7 @@ var createElement = require("../../vdom/create-element")
 var patch = require("../../vdom/patch")
 var diff = require("../../vtree/diff")
 
-test.skip("h with events", function (assert) {
+test("h with events", function (assert) {
     function one() {}
 
     var left = h(".foo", {

--- a/vtree/vnode.js
+++ b/vtree/vnode.js
@@ -20,21 +20,6 @@ function VirtualNode(tagName, properties, children, key, namespace) {
     var descendants = 0
     var hasWidgets = false
     var hasThunks = false
-    var descendantHooks = false
-    var hooks
-
-    for (var propName in properties) {
-        if (properties.hasOwnProperty(propName)) {
-            var property = properties[propName]
-            if (isVHook(property)) {
-                if (!hooks) {
-                    hooks = {}
-                }
-
-                hooks[propName] = property
-            }
-        }
-    }
 
     for (var i = 0; i < count; i++) {
         var child = children[i]
@@ -49,9 +34,6 @@ function VirtualNode(tagName, properties, children, key, namespace) {
                 hasThunks = true
             }
 
-            if (!descendantHooks && (child.hooks || child.descendantHooks)) {
-                descendantHooks = true
-            }
         } else if (!hasWidgets && isWidget(child)) {
             if (typeof child.destroy === "function") {
                 hasWidgets = true
@@ -64,8 +46,6 @@ function VirtualNode(tagName, properties, children, key, namespace) {
     this.count = count + descendants
     this.hasWidgets = hasWidgets
     this.hasThunks = hasThunks
-    this.hooks = hooks
-    this.descendantHooks = descendantHooks
 }
 
 VirtualNode.prototype.version = version


### PR DESCRIPTION
This change converts all hooks into soft hooks.

Soft hooks only get called if the hook value has changed.

This removes weight and performance complexity from the virtual-dom
    implementation. If you want the hook to be invoked again you
    must create a new hook instance that is not referentially equal
    to the old hook.

cc @Matt-Esch
